### PR TITLE
grafana: Add option to share dashboards.

### DIFF
--- a/unit_tests/test_provides.py
+++ b/unit_tests/test_provides.py
@@ -72,17 +72,22 @@ class TestCosAgentProvides(test_utils.PatchHelper):
         expected_path = "/metrics"
         expected_host = "127.0.0.1"
         expected_job_name = "test_job"
+        expected_dashboard = "someB64hash"
         full_job_name = f"{self.ep.endpoint_name}_{endpoint_index}_{expected_job_name}"
         metric_endpoint = provides.MetricsEndpoint(
             port=expected_port,
             path=expected_path,
             host=expected_host,
+            dashboards_dir="/foo/bar/",
             job_name=expected_job_name,
+        )
+        self.patch_object(
+            self.ep, "_encode_dashboards", return_value=[expected_dashboard]
         )
 
         self.ep.update_cos_agent([metric_endpoint])
         expect_rel_data = {
-            "dashboards": [],
+            "dashboards": [expected_dashboard],
             "log_alert_rules": {},
             "log_slots": [],
             "metrics_alert_rules": {},


### PR DESCRIPTION
This change add option to specify directory that
contains grafana dashboards. Each ".json" file in this directory will be encoded into the relation with
grafana-agent charm.

It is responsibility of grafana-agent charm to then import these dashboards into the related grafana application.